### PR TITLE
Provide the username of the authenticated user in the callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ var basic = auth({
  */
 http.createServer(function(req, res) {
 	// Apply authentication to server.
-	basic.apply(req, res, function() {
-		res.end("Welcome to private area!");
+	basic.apply(req, res, function(username) {
+		res.end("Welcome to private area, " + username + "!");
 	});
 }).listen(1337);
 ```	

--- a/lib/auth/basic.js
+++ b/lib/auth/basic.js
@@ -45,7 +45,7 @@ function Basic(authRealm, authUsers) {
 		if(!authenticated) {
 			self.ask(response);
 		} else {
-			next();
+			next(authenticated);
 		}
 	}
 };
@@ -55,9 +55,10 @@ function Basic(authRealm, authUsers) {
  *
  * @param {Request} request HTTP request object.
  * @return {Boolean} true if is authenticated, else false.
+ * @return {String} the authenticated user ID, if authenticated, else undefined.
  */
 Basic.prototype.isAuthenticated = function(request) {
-	var authenticated = false;
+	var authenticated = undefined;
 
 	// If header exists.
 	if("authorization" in request.headers) {
@@ -79,7 +80,7 @@ Basic.prototype.isAuthenticated = function(request) {
 					// Ensure the username and password both match.
 					if(myUserName === clientUserName)  {
 						if(htpasswd.validate(clientPasswordHash, myPasswordHash)) {
-							authenticated = true;
+							authenticated = myUserName;
 							break;
 						}
 					}

--- a/lib/auth/digest.js
+++ b/lib/auth/digest.js
@@ -51,7 +51,7 @@ function Digest(authRealm, authUsers, algorithm) {
 		if(!authenticated) {
 			self.ask(response);
 		} else {
-			next();
+			next(authenticated);
 		}
 	};
 };
@@ -60,10 +60,10 @@ function Digest(authRealm, authUsers, algorithm) {
  * Checks authorization header in request.
  *
  * @param {Request} request HTTP request object.
- * @return {Boolean} true if is authenticated, else false.
+ * @return {String} the authenticated user ID, if authenticated, else undefined.
  */
 Digest.prototype.isAuthenticated = function(request) {
-	var authenticated = false;
+	var authenticated = undefined;
 
 	// If header exists.
 	if("authorization" in request.headers) {
@@ -99,12 +99,12 @@ Digest.prototype.isAuthenticated = function(request) {
 						var authRes = utils.md5(ha1 + ":" + co.nonce + ":" + co.nc + ":" + 
 							co.cnonce + ":" + co.qop + ":" + ha2);						
 												
-						authenticated = (authRes == co.response);
+						authenticated = (authRes == co.response) ? co.username : undefined;
 					}
 				} else {
 					// Evaluating final authentication response.
 					var authRes = utils.md5(ha1 + ":" + co.nonce + ":" + ha2);
-					authenticated = (authRes == co.response);
+					authenticated = (authRes == co.response) ? co.userid : undefined;
 				}
 			}
 		}


### PR DESCRIPTION
This change makes it possible for the callback to provide
the username that was authenticated, avoiding the need to
parse the Authorization header again. How else would you
know who has logged in, so you can provide different levels
of access to different users.

Note, I have only used the digest code (since that's what I use)...
