### PR TITLE
Fixed windows carriage return for users file

### DIFF
--- a/lib/auth/base.coffee
+++ b/lib/auth/base.coffee
@@ -35,7 +35,7 @@ class Base
       
   # Loading files with user details.
   loadUsers: () ->
-    lines = (fs.readFileSync @options.file, 'UTF-8').split "\n"
+    lines = ((fs.readFileSync @options.file, 'UTF-8').replace "\r\n", "\n").split "\n"
     
     for line in lines  
       if line # If line is not empty, process it.


### PR DESCRIPTION
When parsing the .htpasswd file, you split on '\n'. For windows users, '\r' remains in the strings, thus getting added to the password, thus authentication doesn't work for any user :) Fixed.
