### PR TITLE
Added host header as third argument to custom authentication function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ http-auth.iml
 .settings
 gensrc
 _site
+.DS_Store

--- a/src/auth/base.js
+++ b/src/auth/base.js
@@ -111,6 +111,7 @@ class Base {
             let clientOptions = this.parseAuthorization(header);
             if (clientOptions) {
                 searching = true;
+                clientOptions.host = req.headers["host"];
                 this.findUser(req, clientOptions, function (result) {
                     callback.apply(self, [result]);
                 });

--- a/src/auth/digest.js
+++ b/src/auth/digest.js
@@ -111,7 +111,7 @@ class Digest extends Base {
 
                     // Call callback.
                     callback.apply(this, params);
-                }]);
+                }], co.host);
             } else {
                 let found = false;
 


### PR DESCRIPTION
Since I need information about domain being accessed to properly handle authentication, I added this header to ClientOptions and then passed this header to custom checker function as third argument in order to obtain this information in my code and save backward compatibility