### PR TITLE
Improve events

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,32 @@ http.createServer(function (req, res) {
 	res.end("Request successfully proxied!");
 }).listen(1338);
 ```
+
+## Events
+
+The auth middleware emits three types of events: **error**, **fail** and **success**. Each event passes the result object (the error in case of `fail`) and the http request `req` to the listener function.
+
+```javascript
+// Authentication module.
+var auth = require('http-auth');
+var basic = auth.basic({
+    realm: "Simon Area.",
+    file: __dirname + "/../data/users.htpasswd"
+});
+
+basic.on('success', function(result, req) {
+	console.log("User authenticated: " + result.user);
+});
+
+basic.on('fail', function(result, req) {
+	console.log("User authentication failed: " + result.user);
+});
+
+basic.on('error', function(error, req) {
+	console.log("Authentication error: " + error.code + " - " + error.message);
+});
+```
+
 ## Configurations
 
  - `realm` - Authentication realm, by default it is **Users**.

--- a/src/auth/base.js
+++ b/src/auth/base.js
@@ -86,7 +86,7 @@ class Base extends events.EventEmitter {
                 if (callback) {
                     callback.apply(self, [req, res, result]);
                 }
-            } else if (!result.user) {
+            } else if (!result.pass) {
                 self.emit('fail');
                 self.ask(res, result);
             } else {

--- a/src/auth/base.js
+++ b/src/auth/base.js
@@ -81,16 +81,16 @@ class Base extends events.EventEmitter {
         let self = this;
         this.isAuthenticated(req, function (result) {
             if (result instanceof Error) {
-                self.emit('error', result);
+                self.emit('error', result, req);
 
                 if (callback) {
                     callback.apply(self, [req, res, result]);
                 }
             } else if (!result.pass) {
-                self.emit('fail');
+                self.emit('fail', result, req);
                 self.ask(res, result);
             } else {
-                self.emit('success', result);
+                self.emit('success', result, req);
 
                 if (!this.options.skipUser) {
                     req.user = result.user;

--- a/src/auth/basic.js
+++ b/src/auth/basic.js
@@ -71,24 +71,24 @@ class Basic extends Base {
                 if (result instanceof Error) {
                     params = [result]
                 } else {
-                    params = [{ user: result ? username: undefined }];
+                    params = [{ user: username, pass: !!result }];
                 }
 
                 callback.apply(self, params);
             }, req]);
         } else {
             // File based auth.
-            let found = false;
+            let pass = false;
 
             // Loop users to find the matching one.
             this.options.users.forEach(user => {
                 if (user.username === username && this.validate(user.hash, password)) {
-                    found = true;
+                    pass = true;
                 }
             });
 
             // Call final callback.
-            callback.apply(this, [{user: found ? username : undefined}]);
+            callback.apply(this, [{user: username, pass: pass}]);
         }
     }
 }

--- a/src/auth/digest.js
+++ b/src/auth/digest.js
@@ -106,23 +106,23 @@ class Digest extends Base {
                     if (hash instanceof Error) {
                         params = [hash];
                     } else {
-                        params = [{user: self.validate(ha2, co, hash) ? co.username : undefined}];
+                        params = [{user: co.username, pass: !!self.validate(ha2, co, hash)}];
                     }
 
                     // Call callback.
                     callback.apply(this, params);
                 }, req]);
             } else {
-                let found = false;
+                let pass = false;
 
                 // File based, loop users to find the matching one.
                 this.options.users.forEach(user => {
                     if (user.username === co.username && this.validate(ha2, co, user.hash)) {
-                        found = true
+                        pass = true;
                     }
                 });
 
-                callback.apply(this, [{user: found ? co.username : undefined}]);
+                callback.apply(this, [{user: co.username, pass: pass}]);
             }
         } else {
             callback.apply(this, [{stale: true}]);


### PR DESCRIPTION
This PR aims to unify the signature of event callbacks and to enable the forwarding of the username and http request object for all events. 

It does this by removing the double use of the username as the holder of the authentication success state and replacing it with one that is specific to that function.

This allows the event listener function to access the username that tried to login on both the success and fail event and the request object (e.g. to get the requested URL) on all event types.