### PR TITLE
Fix issue with empty or comment lines in htpasswd file

### DIFF
--- a/data/users.htpasswd
+++ b/data/users.htpasswd
@@ -5,3 +5,6 @@ Shanon:noneof
 Mike:pass123
 vera:UdMhBHagv7sUU
 hera:$apr1$fQc7jP4E$cPBB0pK92nO9VxgVvef4k.
+
+# comment: this is a comment with a colon
+#comment:commentpass

--- a/data/users.htpasswd
+++ b/data/users.htpasswd
@@ -6,5 +6,4 @@ Mike:pass123
 vera:UdMhBHagv7sUU
 hera:$apr1$fQc7jP4E$cPBB0pK92nO9VxgVvef4k.
 
-# comment: this is a comment with a colon
 #comment:commentpass

--- a/src/auth/base.js
+++ b/src/auth/base.js
@@ -139,7 +139,9 @@ class Base extends events.EventEmitter {
 
         // Process all users.
         users.forEach(u => {
-            this.processLine(u);
+            if(u && !u.match(/^\s*#.*/)) {
+                this.processLine(u);
+            }
         });
     }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -115,14 +115,4 @@ describe('basic', function () {
         // Test request.
         request.get('http://127.0.0.1:1337', callback).auth('#comment', 'commentpass');
     });
-
-    it('Commented user with space', function (done) {
-        const callback = function(error, response, body) {
-            expect(body).to.equal("401 Unauthorized");
-            done();
-        };
-
-        // Test request.
-        request.get('http://127.0.0.1:1337', callback).auth('# comment', ' this is a comment with a colon');
-    });
 });

--- a/test/basic.js
+++ b/test/basic.js
@@ -95,4 +95,34 @@ describe('basic', function () {
         // Test request.
         request.get('http://127.0.0.1:1337', callback).auth('solomon', 'gpass');
     });
+
+    it('Empty user and password', function (done) {
+        const callback = function(error, response, body) {
+            expect(body).to.equal("401 Unauthorized");
+            done();
+        };
+
+        // Test request.
+        request.get('http://127.0.0.1:1337', callback).auth('', '');
+    });
+
+    it('Commented user', function (done) {
+        const callback = function(error, response, body) {
+            expect(body).to.equal("401 Unauthorized");
+            done();
+        };
+
+        // Test request.
+        request.get('http://127.0.0.1:1337', callback).auth('#comment', 'commentpass');
+    });
+
+    it('Commented user with space', function (done) {
+        const callback = function(error, response, body) {
+            expect(body).to.equal("401 Unauthorized");
+            done();
+        };
+
+        // Test request.
+        request.get('http://127.0.0.1:1337', callback).auth('# comment', ' this is a comment with a colon');
+    });
 });


### PR DESCRIPTION
An empty line in the htpasswd file allowed authentication without a username or password. Apparently, empty lines and comment lines are allowed in a htpasswd file (and my development setup even creates htpasswd files with an empty last line), so these lines need to be excluded from parsing into the options.users array.