### PR TITLE
Add support for custom user added to request

### DIFF
--- a/src/auth/basic.js
+++ b/src/auth/basic.js
@@ -76,13 +76,13 @@ class Basic extends Base {
 
         if (this.checker) {
             // Custom auth.
-            this.checker.apply(this, [username, password, (result) => {
+            this.checker.apply(this, [username, password, (result, customUser) => {
                 let params = undefined;
 
                 if (result instanceof Error) {
                     params = [result]
                 } else {
-                    params = [{ user: username, pass: !!result }];
+                    params = [{ user: customUser || username, pass: !!result }];
                 }
 
                 callback.apply(self, params);


### PR DESCRIPTION
In our scenario, we're using the custom `checker` route to validate the username and password. At this point, we've already got a fully populated instance of the current `user` (assuming they pass, so it'd be much more beneficial to set `req.user` to the full object rather than just the email address. 

I took a stab at adding a quick and easy approach of providing a "custom" user as a second param to the callback, which will be defaulted to if present (and `skipUser` is not set). It's pretty straight forwards and backwards compatible, but happy to pursue other options if there's a cleaner / better / more preferred approach. 