### PR TITLE
New Feature: added skipAuthHeader option

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ basic.on('error', (error, req) => {
  - `msg407` - Message for failed authentication 407 page.
  - `contentType` - Content type for failed authentication page.
  - `skipUser` - Set this to **true**, if you don't want req.user to be filled with authentication info.
+ - `skipAuthHeader` - Set this to **true**, if you don't want to send the WWW-Authenticate header with your response when using Express framework.
 
 ## Running tests
 

--- a/src/auth/base.js
+++ b/src/auth/base.js
@@ -28,6 +28,10 @@ class Base extends events.EventEmitter {
             options.realm = "users";
         }
 
+        if (!options.skipAuthHeader) {
+            options.skipAuthHeader = false;
+        }
+
         // Assign values.
         this.options = options;
         this.checker = checker;
@@ -70,7 +74,9 @@ class Base extends events.EventEmitter {
             res.writeHead(407);
             res.end(this.options.msg407);
         } else {
-            res.setHeader("WWW-Authenticate", header);
+            if (!this.options.skipAuthHeader) {
+                res.setHeader("WWW-Authenticate", header);
+            }
             res.writeHead(401);
             res.end(this.options.msg401);
         }


### PR DESCRIPTION
Hi,
I have a node Express middleware and I am using your http-auth lib. Actually it suits perfect for my needs. But I use it as authorization of my mobile cross platform Ionic app. Since this works in a webView any request which can't pass the authorization times out, because you send the "WWW-Authenticate" header which due to cordova limitations can't be handled.

Check this if you are interested: 

https://stackoverflow.com/questions/30529210/handling-http-401-with-www-authenticate-in-cordova-ionic-ios-application