### PR TITLE
Migrate to higher performance bcrypt implement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,50 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@node-rs/bcrypt": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt/-/bcrypt-0.5.0.tgz",
+      "integrity": "sha512-q5Untj+u5m5hELk5mKF/uYKn10Hk2Kv39dDly3rVuOLTg+pA+Cu7AgOkeO0Nr+f09Xh5Zn5SU1jRd6TA2W2osA==",
+      "requires": {
+        "@node-rs/bcrypt-darwin": "^0.5.0",
+        "@node-rs/bcrypt-linux": "^0.5.0",
+        "@node-rs/bcrypt-win32": "^0.5.0",
+        "@node-rs/helper": "^0.4.0"
+      }
+    },
+    "@node-rs/bcrypt-darwin": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-darwin/-/bcrypt-darwin-0.5.0.tgz",
+      "integrity": "sha512-1A/bAj78FiYk69YeDkhgDzmfVy4fvcbkCmJZOV8EdH+DJc4NeDL+k0YpY1j7YooqLkf4xRc6yCJ00xg8308bMQ==",
+      "optional": true
+    },
+    "@node-rs/bcrypt-linux": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux/-/bcrypt-linux-0.5.0.tgz",
+      "integrity": "sha512-QNrpeRtW9phptg1IcXxp7wqKBSekVMAbd2l/tnz0Web64YsWm5an80mAVsdg1LAt59ClnjXQIzIZV8d028ls9g==",
+      "optional": true
+    },
+    "@node-rs/bcrypt-win32": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-win32/-/bcrypt-win32-0.5.0.tgz",
+      "integrity": "sha512-4MWX4RU/Vx4xZK3s02HiG96R8luvKKF76gaauKrVcaGO3/iUcLlCsdZ7dYt9HPPDwhmG5aPs5bG1a2pxA7lAqQ==",
+      "optional": true
+    },
+    "@node-rs/helper": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/helper/-/helper-0.4.0.tgz",
+      "integrity": "sha512-fSyHEXmlt/FueKqAYiGFCnkohnQBMQwUr6VYPeZEeVBAzQzhioS1WaRe2fSpOuRKIimCQEvxhQ6fwsYxYakfGA==",
+      "requires": {
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+        }
+      }
+    },
     "acorn": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
@@ -169,11 +213,6 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
-    },
-    "bcryptjs": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
     },
     "binary-extensions": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "url": "http://github.com/http-auth/http-auth/issues"
   },
   "dependencies": {
+    "@node-rs/bcrypt": "^0.5.0",
     "apache-crypt": "^1.1.2",
     "apache-md5": "^1.0.6",
-    "bcryptjs": "^2.4.3",
     "uuid": "^3.4.0"
   },
   "devDependencies": {

--- a/src/auth/basic.js
+++ b/src/auth/basic.js
@@ -13,7 +13,7 @@ const md5 = require("apache-md5");
 const crypt = require("apache-crypt");
 
 // Bcrypt.
-const bcrypt = require("bcryptjs");
+const bcrypt = require("@node-rs/bcrypt");
 
 // Crypto.
 const crypto = require("crypto");
@@ -36,7 +36,7 @@ class Basic extends Base {
     } else if (hash.substr(0, 6) === "$apr1$" || hash.substr(0, 3) === "$1$") {
       return hash === md5(password, hash);
     } else if (hash.substr(0, 4) === "$2y$" || hash.substr(0, 4) === "$2a$") {
-      return bcrypt.compareSync(password, hash);
+      return bcrypt.verifySync(password, hash);
     } else if (hash === crypt(password, hash)) {
       return true;
     } else if (hash.length === password.length) {


### PR DESCRIPTION
[@node-rs/bcrypt](https://www.npmjs.com/package/@node-rs/bcrypt) is `4~8x` faster than `bcryptjs`.

And compare to [node bcrypt](https://www.npmjs.com/package/bcrypt), `@node-rs/bcrypt` has no `postinstall` download scripts nor `node-gyp`.


Benchmark:

- [@node-rs/bcrypt](https://www.npmjs.com/package/@node-rs/bcrypt)
- [node bcrypt](https://www.npmjs.com/package/bcrypt)
- [bcryptjs](https://www.npmjs.com/package/bcryptjs)

```bash
@node-rs/bcrypt x 18.78 ops/sec ±0.86% (12 runs sampled)
node bcrypt x 16.28 ops/sec ±3.55% (11 runs sampled)
bcryptjs x 3.70 ops/sec ±2.64% (6 runs sampled)
Async verify bench suite: Fastest is @node-rs/bcrypt
```