### PR TITLE
Using bcryptjs instead of @node-rs/bcrypt which fails in webpack, Fixes #110

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "version": "4.1.4",
       "license": "MIT",
       "dependencies": {
-        "@node-rs/bcrypt": "^1.0.0",
         "apache-crypt": "^1.1.2",
         "apache-md5": "^1.0.6",
+        "bcryptjs": "^2.4.3",
         "uuid": "^3.4.0"
       },
       "devDependencies": {
@@ -52,181 +52,6 @@
         "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
-      }
-    },
-    "node_modules/@napi-rs/triples": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.0.2.tgz",
-      "integrity": "sha512-EL3SiX43m9poFSnhDx4d4fn9SSaqyO2rHsCNhETi9bWPmjXK3uPJ0QpPFtx39FEdHcz1vJmsiW41kqc0AgvtzQ=="
-    },
-    "node_modules/@node-rs/bcrypt": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt/-/bcrypt-1.1.0.tgz",
-      "integrity": "sha512-5vjztYYcPCyvamO3C+hrNaVplZC9yEMzGxJECliQR5hkUOQdrtulCpigNOr1POWpC1YsJH0ZL+ktWop+cl5Qqw==",
-      "dependencies": {
-        "@node-rs/helper": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "optionalDependencies": {
-        "@node-rs/bcrypt-android-arm64": "^1.1.0",
-        "@node-rs/bcrypt-darwin-arm64": "^1.1.0",
-        "@node-rs/bcrypt-darwin-x64": "^1.1.0",
-        "@node-rs/bcrypt-linux-arm-gnueabihf": "^1.1.0",
-        "@node-rs/bcrypt-linux-arm64-gnu": "^1.1.0",
-        "@node-rs/bcrypt-linux-x64-gnu": "^1.1.0",
-        "@node-rs/bcrypt-linux-x64-musl": "^1.1.0",
-        "@node-rs/bcrypt-win32-ia32-msvc": "^1.1.0",
-        "@node-rs/bcrypt-win32-x64-msvc": "^1.1.0"
-      }
-    },
-    "node_modules/@node-rs/bcrypt-android-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-android-arm64/-/bcrypt-android-arm64-1.1.0.tgz",
-      "integrity": "sha512-JWntO90f/0hZzDc77rdULBPPX85huAQWk1AQi/x9a3dlfINkcfm70Grdja2gy4fb9iTYhqMVVfye48owp+bDow==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/bcrypt-darwin-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-darwin-arm64/-/bcrypt-darwin-arm64-1.1.0.tgz",
-      "integrity": "sha512-XMsUCzoVdsu4G/uO5ldGkcjYbhW0s/Qw9yS6FGqcAtmiJD+EvxvaAmEBt8hniPQe+0t2T1YoV0eBqrw6JJ8H+Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/bcrypt-darwin-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-darwin-x64/-/bcrypt-darwin-x64-1.1.0.tgz",
-      "integrity": "sha512-gtppTNHJ0Lxf4YmSnl4B2DMfaXW7wx2GfpzCcFLEIb1KST/J3ns29RO7bkP0yXZkS+d6XZHNdNjU8uhryskd1g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/bcrypt-linux-arm-gnueabihf": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-arm-gnueabihf/-/bcrypt-linux-arm-gnueabihf-1.1.0.tgz",
-      "integrity": "sha512-YXJFjraNNuH6M8bAjSv5xPa0hcWOLfzOfklbip35Jn1GmvTIpPmEuzdKXn3k3vRZU79CzGArpk3qH6dqeKcHJQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/bcrypt-linux-arm64-gnu": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-arm64-gnu/-/bcrypt-linux-arm64-gnu-1.1.0.tgz",
-      "integrity": "sha512-lEAogi8IxFx/7neC//BA7cLYPS0FXc2PkJVk3dxW4G58vi2iQSYM0E+Gx9SzC30EiR+eVp96xPalgIh/13ooHw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/bcrypt-linux-x64-gnu": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-x64-gnu/-/bcrypt-linux-x64-gnu-1.1.0.tgz",
-      "integrity": "sha512-i3lcg4beZEsl7CTB21Y8F/nKh+QVyBFfaIi0B33/9floKjZA3wiwGkmxXSKvUx0Pi4PnnggmuQyVpVHqbb3dFw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/bcrypt-linux-x64-musl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-x64-musl/-/bcrypt-linux-x64-musl-1.1.0.tgz",
-      "integrity": "sha512-6+5xbdGguo2j6UAhhKskx4XxvkAC78Op2smGEMDm/A7NjT7hPn+6+ST91UJvUIS+WXD7tHYOwRhDYmHawVDL3A==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/bcrypt-win32-ia32-msvc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-win32-ia32-msvc/-/bcrypt-win32-ia32-msvc-1.1.0.tgz",
-      "integrity": "sha512-vPagjDSZoTm0Rzx8Eo3sqQdvysFPvOpvdaBzKT7O91nu+yr5J71DMiIxYCnU8uoQ8vEUltwMON+r//PNPj4UGw==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/bcrypt-win32-x64-msvc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-win32-x64-msvc/-/bcrypt-win32-x64-msvc-1.1.0.tgz",
-      "integrity": "sha512-DiFTF0e5Q9xW9F1D8Wet/trxJA9SMO4qcBS77JyQTKKbU3pWi7LuVOOuebuUNyBY/BKPfbaeJK/9mxiS3Be6OA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@node-rs/helper": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/helper/-/helper-1.1.0.tgz",
-      "integrity": "sha512-r43YnnrY5JNzDuXJdW3sBJrKzvejvFmFWbiItUEoBJsaPzOIWFMhXB7i5j4c9EMXcFfxveF4l7hT+rLmwtjrVQ==",
-      "dependencies": {
-        "@napi-rs/triples": "^1.0.2",
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/acorn": {
@@ -435,6 +260,11 @@
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -3067,11 +2897,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
-    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -3435,91 +3260,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@napi-rs/triples": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.0.2.tgz",
-      "integrity": "sha512-EL3SiX43m9poFSnhDx4d4fn9SSaqyO2rHsCNhETi9bWPmjXK3uPJ0QpPFtx39FEdHcz1vJmsiW41kqc0AgvtzQ=="
-    },
-    "@node-rs/bcrypt": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt/-/bcrypt-1.1.0.tgz",
-      "integrity": "sha512-5vjztYYcPCyvamO3C+hrNaVplZC9yEMzGxJECliQR5hkUOQdrtulCpigNOr1POWpC1YsJH0ZL+ktWop+cl5Qqw==",
-      "requires": {
-        "@node-rs/bcrypt-android-arm64": "^1.1.0",
-        "@node-rs/bcrypt-darwin-arm64": "^1.1.0",
-        "@node-rs/bcrypt-darwin-x64": "^1.1.0",
-        "@node-rs/bcrypt-linux-arm-gnueabihf": "^1.1.0",
-        "@node-rs/bcrypt-linux-arm64-gnu": "^1.1.0",
-        "@node-rs/bcrypt-linux-x64-gnu": "^1.1.0",
-        "@node-rs/bcrypt-linux-x64-musl": "^1.1.0",
-        "@node-rs/bcrypt-win32-ia32-msvc": "^1.1.0",
-        "@node-rs/bcrypt-win32-x64-msvc": "^1.1.0",
-        "@node-rs/helper": "^1.1.0"
-      }
-    },
-    "@node-rs/bcrypt-android-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-android-arm64/-/bcrypt-android-arm64-1.1.0.tgz",
-      "integrity": "sha512-JWntO90f/0hZzDc77rdULBPPX85huAQWk1AQi/x9a3dlfINkcfm70Grdja2gy4fb9iTYhqMVVfye48owp+bDow==",
-      "optional": true
-    },
-    "@node-rs/bcrypt-darwin-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-darwin-arm64/-/bcrypt-darwin-arm64-1.1.0.tgz",
-      "integrity": "sha512-XMsUCzoVdsu4G/uO5ldGkcjYbhW0s/Qw9yS6FGqcAtmiJD+EvxvaAmEBt8hniPQe+0t2T1YoV0eBqrw6JJ8H+Q==",
-      "optional": true
-    },
-    "@node-rs/bcrypt-darwin-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-darwin-x64/-/bcrypt-darwin-x64-1.1.0.tgz",
-      "integrity": "sha512-gtppTNHJ0Lxf4YmSnl4B2DMfaXW7wx2GfpzCcFLEIb1KST/J3ns29RO7bkP0yXZkS+d6XZHNdNjU8uhryskd1g==",
-      "optional": true
-    },
-    "@node-rs/bcrypt-linux-arm-gnueabihf": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-arm-gnueabihf/-/bcrypt-linux-arm-gnueabihf-1.1.0.tgz",
-      "integrity": "sha512-YXJFjraNNuH6M8bAjSv5xPa0hcWOLfzOfklbip35Jn1GmvTIpPmEuzdKXn3k3vRZU79CzGArpk3qH6dqeKcHJQ==",
-      "optional": true
-    },
-    "@node-rs/bcrypt-linux-arm64-gnu": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-arm64-gnu/-/bcrypt-linux-arm64-gnu-1.1.0.tgz",
-      "integrity": "sha512-lEAogi8IxFx/7neC//BA7cLYPS0FXc2PkJVk3dxW4G58vi2iQSYM0E+Gx9SzC30EiR+eVp96xPalgIh/13ooHw==",
-      "optional": true
-    },
-    "@node-rs/bcrypt-linux-x64-gnu": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-x64-gnu/-/bcrypt-linux-x64-gnu-1.1.0.tgz",
-      "integrity": "sha512-i3lcg4beZEsl7CTB21Y8F/nKh+QVyBFfaIi0B33/9floKjZA3wiwGkmxXSKvUx0Pi4PnnggmuQyVpVHqbb3dFw==",
-      "optional": true
-    },
-    "@node-rs/bcrypt-linux-x64-musl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-x64-musl/-/bcrypt-linux-x64-musl-1.1.0.tgz",
-      "integrity": "sha512-6+5xbdGguo2j6UAhhKskx4XxvkAC78Op2smGEMDm/A7NjT7hPn+6+ST91UJvUIS+WXD7tHYOwRhDYmHawVDL3A==",
-      "optional": true
-    },
-    "@node-rs/bcrypt-win32-ia32-msvc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-win32-ia32-msvc/-/bcrypt-win32-ia32-msvc-1.1.0.tgz",
-      "integrity": "sha512-vPagjDSZoTm0Rzx8Eo3sqQdvysFPvOpvdaBzKT7O91nu+yr5J71DMiIxYCnU8uoQ8vEUltwMON+r//PNPj4UGw==",
-      "optional": true
-    },
-    "@node-rs/bcrypt-win32-x64-msvc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-win32-x64-msvc/-/bcrypt-win32-x64-msvc-1.1.0.tgz",
-      "integrity": "sha512-DiFTF0e5Q9xW9F1D8Wet/trxJA9SMO4qcBS77JyQTKKbU3pWi7LuVOOuebuUNyBY/BKPfbaeJK/9mxiS3Be6OA==",
-      "optional": true
-    },
-    "@node-rs/helper": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/helper/-/helper-1.1.0.tgz",
-      "integrity": "sha512-r43YnnrY5JNzDuXJdW3sBJrKzvejvFmFWbiItUEoBJsaPzOIWFMhXB7i5j4c9EMXcFfxveF4l7hT+rLmwtjrVQ==",
-      "requires": {
-        "@napi-rs/triples": "^1.0.2",
-        "tslib": "^2.1.0"
-      }
-    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -3674,6 +3414,11 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -5634,11 +5379,6 @@
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
       }
-    },
-    "tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "url": "http://github.com/http-auth/http-auth/issues"
   },
   "dependencies": {
-    "@node-rs/bcrypt": "^1.0.0",
     "apache-crypt": "^1.1.2",
     "apache-md5": "^1.0.6",
+    "bcryptjs": "^2.4.3",
     "uuid": "^3.4.0"
   },
   "devDependencies": {

--- a/src/auth/basic.js
+++ b/src/auth/basic.js
@@ -13,7 +13,7 @@ const md5 = require("apache-md5");
 const crypt = require("apache-crypt");
 
 // Bcrypt.
-const bcrypt = require("@node-rs/bcrypt");
+const bcrypt = require("bcryptjs");
 
 // Crypto.
 const crypto = require("crypto");
@@ -36,7 +36,7 @@ class Basic extends Base {
     } else if (hash.substr(0, 6) === "$apr1$" || hash.substr(0, 3) === "$1$") {
       return hash === md5(password, hash);
     } else if (hash.substr(0, 4) === "$2y$" || hash.substr(0, 4) === "$2a$") {
-      return bcrypt.verifySync(password, hash);
+      return bcrypt.compareSync(password, hash);
     } else if (hash === crypt(password, hash)) {
       return true;
     } else if (hash.length === password.length) {


### PR DESCRIPTION
Using bcryptjs instead of @node-rs/bcrypt which fails in webpack

Change-Id: I2465a00f298c72f65443ae594e1fb37100f82022